### PR TITLE
Proxy Container & Invoker

### DIFF
--- a/src/ObjectFieldResolver/Middleware/AbstractObjectFieldByReflectionMethodMiddleware.php
+++ b/src/ObjectFieldResolver/Middleware/AbstractObjectFieldByReflectionMethodMiddleware.php
@@ -10,6 +10,7 @@ use Andi\GraphQL\TypeRegistryInterface;
 use GraphQL\Type\Definition as Webonyx;
 use ReflectionMethod;
 use Spiral\Attributes\ReaderInterface;
+use Spiral\Core\Attribute\Proxy;
 use Spiral\Core\InvokerInterface;
 use Spiral\Core\ScopeInterface;
 
@@ -24,7 +25,9 @@ abstract class AbstractObjectFieldByReflectionMethodMiddleware extends AbstractF
         ReaderInterface $reader,
         TypeRegistryInterface $typeRegistry,
         ArgumentResolverInterface $argumentResolver,
+        #[Proxy]
         private readonly ScopeInterface $scope,
+        #[Proxy]
         private readonly InvokerInterface $invoker,
     ) {
         parent::__construct($reader, $typeRegistry, $argumentResolver);

--- a/src/ObjectFieldResolver/Middleware/AbstractOuterObjectFieldByReflectionMethodMiddleware.php
+++ b/src/ObjectFieldResolver/Middleware/AbstractOuterObjectFieldByReflectionMethodMiddleware.php
@@ -10,6 +10,7 @@ use Andi\GraphQL\TypeRegistryInterface;
 use GraphQL\Type\Definition as Webonyx;
 use ReflectionMethod;
 use Spiral\Attributes\ReaderInterface;
+use Spiral\Core\Attribute\Proxy;
 use Spiral\Core\InvokerInterface;
 use Spiral\Core\ScopeInterface;
 
@@ -19,7 +20,9 @@ abstract class AbstractOuterObjectFieldByReflectionMethodMiddleware extends Abst
         ReaderInterface $reader,
         TypeRegistryInterface $typeRegistry,
         ArgumentResolverInterface $argumentResolver,
+        #[Proxy]
         private readonly ScopeInterface $scope,
+        #[Proxy]
         private readonly InvokerInterface $invoker,
     ) {
         parent::__construct($reader, $typeRegistry, $argumentResolver);


### PR DESCRIPTION
Without proxying the container & invoker, all container binding resolution was performed in the "root" scope. This led to the invoker being unable to resolve scope-dependent arguments:

```php
#[QueryField(name: 'customer')]
public function getCustomer(
  #[Argument(type: 'ID!')]
  string $id,
  ActorInterface $actor, // https://spiral.dev/docs/security-authentication/current
): Customer {
  ...
}
```

Without these changes, it would lead to `Can't resolve 'ActorInterface'` exception